### PR TITLE
% fix for transactions that where not being properly completed.

### DIFF
--- a/Classes/SCPStoreKitManager.m
+++ b/Classes/SCPStoreKitManager.m
@@ -128,9 +128,19 @@
 
 #pragma mark - SKPaymentTransactionObserver methods
 
+- (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue
+{
+    [self validateQueue:queue withTransactions:queue.transactions];
+}
+
 - (void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray *)transactions
 {
-	if([transactions count] > 0)
+    [self validateQueue:queue withTransactions:transactions];
+}
+
+- (void) validateQueue:(SKPaymentQueue *)queue withTransactions:(NSArray *)transactions
+{
+    if([transactions count] > 0)
 	{
 		[transactions enumerateObjectsUsingBlock:^(SKPaymentTransaction *transaction, NSUInteger idx, BOOL *stop) {
 			


### PR DESCRIPTION
Prior to iOS 9 release, a scenario started happening where users where presented with the message "Non-Renewing Subscription Already purchased".  This is the fix for that specific behaviour.

http://stackoverflow.com/questions/26401275/non-renewing-subscription-already-purchased-alert-track
